### PR TITLE
[Bug] release artifact tarball containing a unexpected parent directory.

### DIFF
--- a/.github/workflows/publish-tagged-commit-to-releases-branch.yml
+++ b/.github/workflows/publish-tagged-commit-to-releases-branch.yml
@@ -33,7 +33,7 @@ jobs:
           run: |
             mkdir -p /tmp/cloudflare-ddns-edgeos/
             while IFS= read -r filename ; do if [ -f ./"$filename" ]; then cp "$filename" /tmp/cloudflare-ddns-edgeos/ ; fi ; done < ./dev-misc/release-file-include
-            tar -cvz --exclude-vcs -f /tmp/cloudflare-ddns-edgeos.tar.gz /tmp/cloudflare-ddns-edgeos/
+            tar -cvz --exclude-vcs -f /tmp/cloudflare-ddns-edgeos.tar.gz -C /tmp cloudflare-ddns-edgeos
             mkdir ./release_dir && mv /tmp/cloudflare-ddns-edgeos.tar.gz ./release_dir
         
         - name: Commit & Push to release branch
@@ -44,7 +44,7 @@ jobs:
             REPO: self
             BRANCH: releases
             FOLDER: release_dir
-            SQUASH_HISTORY: false
+            SQUASH_HISTORY: true
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             MESSAGE: ${{ steps.tagcheck.outputs.tagname }}
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,13 @@ Thus...this project.
 
 ## Release/Feature History
 
+### v1.2
+
++ Continuous-Delivery via `Github Action` is configured, build and push artifact to `releases` branch.
+
 ### v1.1
 
 + Automatically create dns record (No need to create record manually in advance).
-
-+ Continuous-Delivery via `Github Action` is configured, build and push artifact to `releases` branch.
 
 + Documentation & comments update (following shell style guideline).
 


### PR DESCRIPTION
Release artifact tarball containing a unexpected parent directory.

Fixed by `tar -C`.

`releases` branch history will be squashed.